### PR TITLE
fix: OAuth2 login behind reverse proxy

### DIFF
--- a/src/main/java/com/nomnomnow/nnnbackend/config/SecurityConfig.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(oAuth2UserService(appUserService))
                         )
-                        .defaultSuccessUrl(frontendUrl, true)
+                        .defaultSuccessUrl(frontendUrl + "/home", true)
                 );
         return http.build();
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,9 @@
 app:
   frontend-url: ${FRONTEND_URL:http://localhost:5173}
 
+server:
+  forward-headers-strategy: framework
+
 spring:
   application:
     name: "NomNomNowBackend"


### PR DESCRIPTION
## Problem
The backend is behind a Caddy reverse proxy that handles TLS. Without `server.forward-headers-strategy: framework`, Spring generates `http://` OAuth2 redirect URIs instead of `https://`, causing Google OAuth to fail.

Additionally, after successful login, `defaultSuccessUrl` redirected to `/` (the login page) instead of `/home`.

## Changes
- **application.yaml**: Added `server.forward-headers-strategy: framework` so Spring trusts `X-Forwarded-*` headers from Caddy
- **SecurityConfig.java**: Changed post-login redirect from `frontendUrl` to `frontendUrl + "/home"`

## Server config also fixed (not in this PR)
- Caddyfile updated to route `/oauth2/*` and `/login/*` to the backend
- `FRONTEND_URL` fixed to include `https://` prefix
- Swapped Google OAuth credentials (client ID/secret were in the wrong env vars)