### PR TITLE
Feature/get user recipes

### DIFF
--- a/src/main/java/com/nomnomnow/nnnbackend/controller/RecipeController.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/controller/RecipeController.java
@@ -78,6 +78,16 @@ public class RecipeController {
 
     }
 
+    @GetMapping("/user/{userId}")
+    public Page<RecipeResponse> getUserRecipes(
+            @PathVariable long userId,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Max(50) int size
+    ) {
+        return recipeService.findByOwner(userId, PageRequest.of(page, size))
+                .map(recipeMapper::toResponse);
+    }
+
     @GetMapping("/{id}/image")
     public ResponseEntity<byte[]> getRecipeImage(@PathVariable long id) {
         var recipe = recipeService.getRecipeImage(id);

--- a/src/main/java/com/nomnomnow/nnnbackend/repository/RecipeRepository.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/repository/RecipeRepository.java
@@ -13,5 +13,8 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     @EntityGraph(attributePaths = {"components.ingredient"})
     Page<Recipe> findAll(Pageable pageable);
 
+    @EntityGraph(attributePaths = {"components.ingredient"})
+    Page<Recipe> findByOwnerId(Long ownerId, Pageable pageable);
+
     boolean existsByName(String name);
 }

--- a/src/main/java/com/nomnomnow/nnnbackend/service/RecipeService.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/service/RecipeService.java
@@ -81,6 +81,11 @@ public class RecipeService {
     }
 
     @Transactional(readOnly = true)
+    public Page<Recipe> findByOwner(Long ownerId, Pageable pageable) {
+        return recipeRepository.findByOwnerId(ownerId, pageable);
+    }
+
+    @Transactional(readOnly = true)
     public Recipe getRecipeImage(long recipeId) {
         var recipe = findRecipe(recipeId);
 

--- a/src/test/java/com/nomnomnow/nnnbackend/controller/RecipeControllerTest.java
+++ b/src/test/java/com/nomnomnow/nnnbackend/controller/RecipeControllerTest.java
@@ -1,5 +1,6 @@
 package com.nomnomnow.nnnbackend.controller;
 
+import com.nomnomnow.nnnbackend.entity.Recipe;
 import com.nomnomnow.nnnbackend.exception.BadRequestException;
 import com.nomnomnow.nnnbackend.exception.GlobalExceptionHandler;
 import com.nomnomnow.nnnbackend.mapper.RecipeMapper;
@@ -10,13 +11,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -65,6 +74,28 @@ class RecipeControllerTest {
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.status").value(409))
                 .andExpect(jsonPath("$.message", containsString("old unique constraint")));
+    }
+
+    @Test
+    void getUserRecipesDelegatesToServiceWithCorrectUserId() throws Exception {
+        var emptyPage = new PageImpl<Recipe>(new ArrayList<>());
+        when(recipeService.findByOwner(eq(42L), any(PageRequest.class))).thenReturn(emptyPage);
+
+        mockMvc.perform(get("/recipes/user/42"));
+
+        verify(recipeService).findByOwner(eq(42L), any(PageRequest.class));
+    }
+
+    @Test
+    void getUserRecipesPassesPaginationParameters() throws Exception {
+        var emptyPage = new PageImpl<Recipe>(new ArrayList<>());
+        when(recipeService.findByOwner(eq(7L), any(PageRequest.class))).thenReturn(emptyPage);
+
+        mockMvc.perform(get("/recipes/user/7")
+                .param("page", "2")
+                .param("size", "10"));
+
+        verify(recipeService).findByOwner(eq(7L), eq(PageRequest.of(2, 10)));
     }
 
     private String validRecipeJson() {

--- a/src/test/java/com/nomnomnow/nnnbackend/service/RecipeServiceTest.java
+++ b/src/test/java/com/nomnomnow/nnnbackend/service/RecipeServiceTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.AccessDeniedException;
 
 import java.math.BigDecimal;
@@ -150,6 +152,37 @@ class RecipeServiceTest {
 
         verify(recipeRepository, never()).saveAndFlush(any());
         verifyNoInteractions(ingredientRepository, recipeComponentRepository);
+    }
+
+    @Test
+    void findByOwnerReturnsRecipesForGivenUser() {
+        var owner = user(42L);
+        var recipe1 = recipe(1L, owner);
+        var recipe2 = recipe(2L, owner);
+        var pageable = PageRequest.of(0, 20);
+        var expectedPage = new PageImpl<>(List.of(recipe1, recipe2), pageable, 2);
+
+        when(recipeRepository.findByOwnerId(42L, pageable)).thenReturn(expectedPage);
+
+        var result = recipeService.findByOwner(42L, pageable);
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).containsExactly(recipe1, recipe2);
+        verify(recipeRepository).findByOwnerId(42L, pageable);
+    }
+
+    @Test
+    void findByOwnerReturnsEmptyPageWhenUserHasNoRecipes() {
+        var pageable = PageRequest.of(0, 20);
+        var emptyPage = new PageImpl<>(List.<Recipe>of(), pageable, 0);
+
+        when(recipeRepository.findByOwnerId(99L, pageable)).thenReturn(emptyPage);
+
+        var result = recipeService.findByOwner(99L, pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        verify(recipeRepository).findByOwnerId(99L, pageable);
     }
 
     private RecipeRequest request() {


### PR DESCRIPTION
This pull request adds a new API endpoint to retrieve recipes owned by a specific user, along with the necessary repository and service methods, and includes comprehensive tests for the new functionality. The changes are grouped into API/controller updates, service/repository logic, and testing enhancements.

**API and Controller Enhancements:**

* Added a new `GET /recipes/user/{userId}` endpoint in `RecipeController` to allow fetching paginated recipes for a specific user. (`src/main/java/com/nomnomnow/nnnbackend/controller/RecipeController.java`)

**Service and Repository Updates:**

* Introduced a new method `findByOwner(Long ownerId, Pageable pageable)` in `RecipeService` to fetch recipes by user, and the corresponding `findByOwnerId` method in `RecipeRepository` with an `@EntityGraph` for eager loading of ingredients. (`src/main/java/com/nomnomnow/nnnbackend/service/RecipeService.java`, `src/main/java/com/nomnomnow/nnnbackend/repository/RecipeRepository.java`) [[1]](diffhunk://#diff-6feea52533f31776c67100adc3e3c22170c4ac53a8e44a8847bcf225e0f9a8ccR83-R87) [[2]](diffhunk://#diff-d30ea52777788af7f799acc06829611f4132974a0db3e36bd95aa363690d165fR16-R18)

**Testing Improvements:**

* Added controller tests to verify correct delegation to the service and proper handling of pagination parameters for the new endpoint. (`src/test/java/com/nomnomnow/nnnbackend/controller/RecipeControllerTest.java`)
* Added service tests to ensure `findByOwner` returns the correct recipes for a user and handles the empty case. (`src/test/java/com/nomnomnow/nnnbackend/service/RecipeServiceTest.java`)
* Included necessary imports and test setup code to support the new tests. (`src/test/java/com/nomnomnow/nnnbackend/controller/RecipeControllerTest.java`, `src/test/java/com/nomnomnow/nnnbackend/service/RecipeServiceTest.java`) [[1]](diffhunk://#diff-bb1b8f223fb57aae93ef77e076dedb4ff0d5656b3e4920cb8de2df6b49904423R3) [[2]](diffhunk://#diff-bb1b8f223fb57aae93ef77e076dedb4ff0d5656b3e4920cb8de2df6b49904423R14-R28) [[3]](diffhunk://#diff-14caabdf62a7e358d6ff604d1531c5678dc8e6980497ea45fc15445517019e5cR20-R21)