### PR TITLE
Feat/recipe search

### DIFF
--- a/src/main/java/com/nomnomnow/nnnbackend/controller/RecipeController.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/controller/RecipeController.java
@@ -78,6 +78,16 @@ public class RecipeController {
 
     }
 
+    @GetMapping("/user/{userId}")
+    public Page<RecipeResponse> getUserRecipes(
+            @PathVariable long userId,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Max(50) int size
+    ) {
+        return recipeService.findByOwner(userId, PageRequest.of(page, size))
+                .map(recipeMapper::toResponse);
+    }
+
     @GetMapping("/{id}/image")
     public ResponseEntity<byte[]> getRecipeImage(@PathVariable long id) {
         var recipe = recipeService.getRecipeImage(id);

--- a/src/main/java/com/nomnomnow/nnnbackend/controller/RecipeController.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/controller/RecipeController.java
@@ -70,22 +70,29 @@ public class RecipeController {
 
     @GetMapping
     public Page<RecipeResponse> getAllRecipes(
+            @RequestParam(required = false) String q,
             @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "20") @Max(50) int size
     ) {
-        return recipeService.findAll(PageRequest.of(page, size))
-                .map(recipeMapper::toResponse);
-
+        var pageable = PageRequest.of(page, size);
+        var recipes = (q != null && !q.isBlank())
+                ? recipeService.search(q, pageable)
+                : recipeService.findAll(pageable);
+        return recipes.map(recipeMapper::toResponse);
     }
 
     @GetMapping("/user/{userId}")
     public Page<RecipeResponse> getUserRecipes(
             @PathVariable long userId,
+            @RequestParam(required = false) String q,
             @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "20") @Max(50) int size
     ) {
-        return recipeService.findByOwner(userId, PageRequest.of(page, size))
-                .map(recipeMapper::toResponse);
+        var pageable = PageRequest.of(page, size);
+        var recipes = (q != null && !q.isBlank())
+                ? recipeService.searchByOwner(userId, q, pageable)
+                : recipeService.findByOwner(userId, pageable);
+        return recipes.map(recipeMapper::toResponse);
     }
 
     @GetMapping("/{id}/image")

--- a/src/main/java/com/nomnomnow/nnnbackend/repository/RecipeRepository.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/repository/RecipeRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
@@ -15,6 +17,34 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     @EntityGraph(attributePaths = {"components.ingredient"})
     Page<Recipe> findByOwnerId(Long ownerId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"components.ingredient"})
+    @Query("""
+        SELECT r FROM Recipe r
+        WHERE LOWER(r.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '\\'
+           OR r.id IN (
+             SELECT rc.recipe.id FROM RecipeComponent rc
+             JOIN rc.ingredient i
+             WHERE LOWER(i.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '\\'
+           )
+    """)
+    Page<Recipe> searchByNameOrIngredient(@Param("q") String query, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"components.ingredient"})
+    @Query("""
+        SELECT r FROM Recipe r
+        WHERE r.owner.id = :ownerId
+          AND (LOWER(r.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '\\'
+               OR r.id IN (
+                 SELECT rc.recipe.id FROM RecipeComponent rc
+                 JOIN rc.ingredient i
+                 WHERE LOWER(i.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '\\'
+               ))
+    """)
+    Page<Recipe> searchByOwnerAndNameOrIngredient(
+            @Param("ownerId") Long ownerId,
+            @Param("q") String query,
+            Pageable pageable);
 
     boolean existsByName(String name);
 }

--- a/src/main/java/com/nomnomnow/nnnbackend/repository/RecipeRepository.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/repository/RecipeRepository.java
@@ -13,5 +13,8 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     @EntityGraph(attributePaths = {"components.ingredient"})
     Page<Recipe> findAll(Pageable pageable);
 
+    @EntityGraph(attributePaths = {"components.ingredient"})
+    Page<Recipe> findByOwnerId(Long ownerId, Pageable pageable);
+
     boolean existsByName(String name);
 }

--- a/src/main/java/com/nomnomnow/nnnbackend/service/RecipeService.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/service/RecipeService.java
@@ -81,6 +81,11 @@ public class RecipeService {
     }
 
     @Transactional(readOnly = true)
+    public Page<Recipe> findByOwner(Long ownerId, Pageable pageable) {
+        return recipeRepository.findByOwnerId(ownerId, pageable);
+    }
+
+    @Transactional(readOnly = true)
     public Recipe getRecipeImage(long recipeId) {
         var recipe = findRecipe(recipeId);
 

--- a/src/main/java/com/nomnomnow/nnnbackend/service/RecipeService.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/service/RecipeService.java
@@ -86,6 +86,20 @@ public class RecipeService {
     }
 
     @Transactional(readOnly = true)
+    public Page<Recipe> search(String query, Pageable pageable) {
+        return recipeRepository.searchByNameOrIngredient(escapeLike(query), pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Recipe> searchByOwner(Long ownerId, String query, Pageable pageable) {
+        return recipeRepository.searchByOwnerAndNameOrIngredient(ownerId, escapeLike(query), pageable);
+    }
+
+    static String escapeLike(String value) {
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+    }
+
+    @Transactional(readOnly = true)
     public Recipe getRecipeImage(long recipeId) {
         var recipe = findRecipe(recipeId);
 

--- a/src/test/java/com/nomnomnow/nnnbackend/controller/RecipeControllerTest.java
+++ b/src/test/java/com/nomnomnow/nnnbackend/controller/RecipeControllerTest.java
@@ -1,5 +1,6 @@
 package com.nomnomnow.nnnbackend.controller;
 
+import com.nomnomnow.nnnbackend.entity.Recipe;
 import com.nomnomnow.nnnbackend.exception.BadRequestException;
 import com.nomnomnow.nnnbackend.exception.GlobalExceptionHandler;
 import com.nomnomnow.nnnbackend.mapper.RecipeMapper;
@@ -10,13 +11,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -65,6 +74,28 @@ class RecipeControllerTest {
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.status").value(409))
                 .andExpect(jsonPath("$.message", containsString("old unique constraint")));
+    }
+
+    @Test
+    void getUserRecipesDelegatesToServiceWithCorrectUserId() throws Exception {
+        var emptyPage = new PageImpl<Recipe>(new ArrayList<>());
+        when(recipeService.findByOwner(eq(42L), any(PageRequest.class))).thenReturn(emptyPage);
+
+        mockMvc.perform(get("/recipes/user/42"));
+
+        verify(recipeService).findByOwner(eq(42L), any(PageRequest.class));
+    }
+
+    @Test
+    void getUserRecipesPassesPaginationParameters() throws Exception {
+        var emptyPage = new PageImpl<Recipe>(new ArrayList<>());
+        when(recipeService.findByOwner(eq(7L), any(PageRequest.class))).thenReturn(emptyPage);
+
+        mockMvc.perform(get("/recipes/user/7")
+                .param("page", "2")
+                .param("size", "10"));
+
+        verify(recipeService).findByOwner(eq(7L), eq(PageRequest.of(2, 10)));
     }
 
     private String validRecipeJson() {

--- a/src/test/java/com/nomnomnow/nnnbackend/controller/RecipeControllerTest.java
+++ b/src/test/java/com/nomnomnow/nnnbackend/controller/RecipeControllerTest.java
@@ -98,6 +98,46 @@ class RecipeControllerTest {
         verify(recipeService).findByOwner(eq(7L), eq(PageRequest.of(2, 10)));
     }
 
+    @Test
+    void getAllRecipesWithQueryDelegatesToSearch() throws Exception {
+        var emptyPage = new PageImpl<Recipe>(new ArrayList<>());
+        when(recipeService.search(eq("pizza"), any(PageRequest.class))).thenReturn(emptyPage);
+
+        mockMvc.perform(get("/recipes").param("q", "pizza"));
+
+        verify(recipeService).search(eq("pizza"), any(PageRequest.class));
+    }
+
+    @Test
+    void getAllRecipesWithoutQueryDelegatesToFindAll() throws Exception {
+        var emptyPage = new PageImpl<Recipe>(new ArrayList<>());
+        when(recipeService.findAll(any(PageRequest.class))).thenReturn(emptyPage);
+
+        mockMvc.perform(get("/recipes"));
+
+        verify(recipeService).findAll(any(PageRequest.class));
+    }
+
+    @Test
+    void getUserRecipesWithQueryDelegatesToSearchByOwner() throws Exception {
+        var emptyPage = new PageImpl<Recipe>(new ArrayList<>());
+        when(recipeService.searchByOwner(eq(42L), eq("pasta"), any(PageRequest.class))).thenReturn(emptyPage);
+
+        mockMvc.perform(get("/recipes/user/42").param("q", "pasta"));
+
+        verify(recipeService).searchByOwner(eq(42L), eq("pasta"), any(PageRequest.class));
+    }
+
+    @Test
+    void getUserRecipesWithBlankQueryDelegatesToFindByOwner() throws Exception {
+        var emptyPage = new PageImpl<Recipe>(new ArrayList<>());
+        when(recipeService.findByOwner(eq(42L), any(PageRequest.class))).thenReturn(emptyPage);
+
+        mockMvc.perform(get("/recipes/user/42").param("q", "   "));
+
+        verify(recipeService).findByOwner(eq(42L), any(PageRequest.class));
+    }
+
     private String validRecipeJson() {
         return """
                 {

--- a/src/test/java/com/nomnomnow/nnnbackend/service/RecipeServiceTest.java
+++ b/src/test/java/com/nomnomnow/nnnbackend/service/RecipeServiceTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.AccessDeniedException;
 
 import java.math.BigDecimal;
@@ -150,6 +152,37 @@ class RecipeServiceTest {
 
         verify(recipeRepository, never()).saveAndFlush(any());
         verifyNoInteractions(ingredientRepository, recipeComponentRepository);
+    }
+
+    @Test
+    void findByOwnerReturnsRecipesForGivenUser() {
+        var owner = user(42L);
+        var recipe1 = recipe(1L, owner);
+        var recipe2 = recipe(2L, owner);
+        var pageable = PageRequest.of(0, 20);
+        var expectedPage = new PageImpl<>(List.of(recipe1, recipe2), pageable, 2);
+
+        when(recipeRepository.findByOwnerId(42L, pageable)).thenReturn(expectedPage);
+
+        var result = recipeService.findByOwner(42L, pageable);
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).containsExactly(recipe1, recipe2);
+        verify(recipeRepository).findByOwnerId(42L, pageable);
+    }
+
+    @Test
+    void findByOwnerReturnsEmptyPageWhenUserHasNoRecipes() {
+        var pageable = PageRequest.of(0, 20);
+        var emptyPage = new PageImpl<>(List.<Recipe>of(), pageable, 0);
+
+        when(recipeRepository.findByOwnerId(99L, pageable)).thenReturn(emptyPage);
+
+        var result = recipeService.findByOwner(99L, pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        verify(recipeRepository).findByOwnerId(99L, pageable);
     }
 
     private RecipeRequest request() {

--- a/src/test/java/com/nomnomnow/nnnbackend/service/RecipeServiceTest.java
+++ b/src/test/java/com/nomnomnow/nnnbackend/service/RecipeServiceTest.java
@@ -185,6 +185,56 @@ class RecipeServiceTest {
         verify(recipeRepository).findByOwnerId(99L, pageable);
     }
 
+    @Test
+    void searchDelegatesToRepositoryAndEscapesWildcards() {
+        var pageable = PageRequest.of(0, 20);
+        var recipe = recipe(1L, user(42L));
+        var expectedPage = new PageImpl<>(List.of(recipe), pageable, 1);
+
+        when(recipeRepository.searchByNameOrIngredient("pizza", pageable)).thenReturn(expectedPage);
+
+        var result = recipeService.search("pizza", pageable);
+
+        assertThat(result.getContent()).hasSize(1);
+        verify(recipeRepository).searchByNameOrIngredient("pizza", pageable);
+    }
+
+    @Test
+    void searchEscapesPercentAndUnderscore() {
+        var pageable = PageRequest.of(0, 20);
+        var emptyPage = new PageImpl<>(List.<Recipe>of(), pageable, 0);
+
+        when(recipeRepository.searchByNameOrIngredient("100\\%", pageable)).thenReturn(emptyPage);
+
+        var result = recipeService.search("100%", pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        verify(recipeRepository).searchByNameOrIngredient("100\\%", pageable);
+    }
+
+    @Test
+    void searchByOwnerDelegatesToRepository() {
+        var pageable = PageRequest.of(0, 20);
+        var recipe = recipe(1L, user(42L));
+        var expectedPage = new PageImpl<>(List.of(recipe), pageable, 1);
+
+        when(recipeRepository.searchByOwnerAndNameOrIngredient(42L, "soup", pageable)).thenReturn(expectedPage);
+
+        var result = recipeService.searchByOwner(42L, "soup", pageable);
+
+        assertThat(result.getContent()).hasSize(1);
+        verify(recipeRepository).searchByOwnerAndNameOrIngredient(42L, "soup", pageable);
+    }
+
+    @Test
+    void escapeLikeHandlesAllSpecialChars() {
+        assertThat(RecipeService.escapeLike("abc")).isEqualTo("abc");
+        assertThat(RecipeService.escapeLike("test%")).isEqualTo("test\\%");
+        assertThat(RecipeService.escapeLike("a_b")).isEqualTo("a\\_b");
+        assertThat(RecipeService.escapeLike("50% off_")).isEqualTo("50\\% off\\_");
+        assertThat(RecipeService.escapeLike("back\\slash")).isEqualTo("back\\\\slash");
+    }
+
     private RecipeRequest request() {
         return new RecipeRequest(
                 " Updated Recipe ",


### PR DESCRIPTION
This pull request adds search and filtering capabilities to the recipe endpoints, allowing users to search recipes by name or ingredient, and to filter recipes by owner. It also introduces pagination and improves test coverage for these new features.

**API enhancements:**

* Added support for searching recipes by name or ingredient using the `q` query parameter in the `GET /recipes` endpoint, and for filtering recipes by owner with `GET /recipes/user/{userId}`. Both endpoints now support pagination and searching.

**Repository and service layer updates:**

* Introduced new repository methods: `findByOwnerId`, `searchByNameOrIngredient`, and `searchByOwnerAndNameOrIngredient` with appropriate JPA queries to support filtering and searching.
* Added corresponding service methods (`findByOwner`, `search`, `searchByOwner`) and a utility method `escapeLike` to safely handle SQL LIKE wildcards.

**Test improvements:**

* Added comprehensive controller tests to verify correct delegation and parameter passing for the new endpoints and query parameters.
* Expanded service tests to cover the new repository methods, search logic, and wildcard escaping.

**Test setup and imports:**

* Updated test files to import necessary classes for mocking, pagination, and assertions. [[1]](diffhunk://#diff-bb1b8f223fb57aae93ef77e076dedb4ff0d5656b3e4920cb8de2df6b49904423R3) [[2]](diffhunk://#diff-bb1b8f223fb57aae93ef77e076dedb4ff0d5656b3e4920cb8de2df6b49904423R14-R28) [[3]](diffhunk://#diff-14caabdf62a7e358d6ff604d1531c5678dc8e6980497ea45fc15445517019e5cR20-R21)