### PR TITLE
Add weekly plan refresh and shopping lists

### DIFF
--- a/flyway/sql/V10__create_shopping_list.sql
+++ b/flyway/sql/V10__create_shopping_list.sql
@@ -1,0 +1,19 @@
+CREATE TABLE app.shopping_list (
+    id BIGSERIAL PRIMARY KEY,
+    owner_id BIGINT NOT NULL,
+    week_start DATE NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT fk_shopping_list_owner FOREIGN KEY (owner_id) REFERENCES app.app_user(id) ON DELETE CASCADE
+);
+
+CREATE TABLE app.shopping_list_item (
+    id BIGSERIAL PRIMARY KEY,
+    shopping_list_id BIGINT NOT NULL,
+    ingredient_name TEXT NOT NULL,
+    quantity NUMERIC(10, 2) NOT NULL,
+    unit TEXT NOT NULL,
+    CONSTRAINT fk_shopping_list_item_list FOREIGN KEY (shopping_list_id) REFERENCES app.shopping_list(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_shopping_list_owner_created ON app.shopping_list(owner_id, created_at DESC);
+CREATE INDEX idx_shopping_list_item_list ON app.shopping_list_item(shopping_list_id);

--- a/src/main/java/com/nomnomnow/nnnbackend/controller/RecipePlanController.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/controller/RecipePlanController.java
@@ -30,4 +30,10 @@ public class RecipePlanController {
             @Valid @RequestBody RecipePlanRequest request) {
         return ResponseEntity.ok(recipePlanService.saveWeeklyPlan(request));
     }
+
+    @PatchMapping("/{planDate}/refresh")
+    public ResponseEntity<RecipePlanResponse> refreshPlanDay(
+            @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate planDate) {
+        return ResponseEntity.ok(recipePlanService.refreshPlanDay(planDate));
+    }
 }

--- a/src/main/java/com/nomnomnow/nnnbackend/controller/ShoppingListController.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/controller/ShoppingListController.java
@@ -1,0 +1,34 @@
+package com.nomnomnow.nnnbackend.controller;
+
+import com.nomnomnow.nnnbackend.dto.request.ShoppingListRequest;
+import com.nomnomnow.nnnbackend.dto.response.ShoppingListResponse;
+import com.nomnomnow.nnnbackend.dto.response.ShoppingListSummaryResponse;
+import com.nomnomnow.nnnbackend.service.ShoppingListService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/shopping-lists")
+@RequiredArgsConstructor
+public class ShoppingListController {
+
+    private final ShoppingListService shoppingListService;
+
+    @PostMapping
+    public ShoppingListResponse generateShoppingList(@Valid @RequestBody ShoppingListRequest request) {
+        return shoppingListService.generateShoppingList(request);
+    }
+
+    @GetMapping
+    public List<ShoppingListSummaryResponse> getShoppingLists() {
+        return shoppingListService.getShoppingLists();
+    }
+
+    @GetMapping("/{id}")
+    public ShoppingListResponse getShoppingList(@PathVariable Long id) {
+        return shoppingListService.getShoppingList(id);
+    }
+}

--- a/src/main/java/com/nomnomnow/nnnbackend/dto/request/ShoppingListRequest.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/dto/request/ShoppingListRequest.java
@@ -1,0 +1,10 @@
+package com.nomnomnow.nnnbackend.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record ShoppingListRequest(
+        @NotNull LocalDate weekStart
+) {
+}

--- a/src/main/java/com/nomnomnow/nnnbackend/dto/response/ShoppingListItemResponse.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/dto/response/ShoppingListItemResponse.java
@@ -1,0 +1,12 @@
+package com.nomnomnow.nnnbackend.dto.response;
+
+import com.nomnomnow.nnnbackend.entity.Unit;
+
+import java.math.BigDecimal;
+
+public record ShoppingListItemResponse(
+        String ingredientName,
+        BigDecimal quantity,
+        Unit unit
+) {
+}

--- a/src/main/java/com/nomnomnow/nnnbackend/dto/response/ShoppingListResponse.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/dto/response/ShoppingListResponse.java
@@ -1,0 +1,13 @@
+package com.nomnomnow.nnnbackend.dto.response;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record ShoppingListResponse(
+        Long id,
+        LocalDate weekStart,
+        OffsetDateTime createdAt,
+        List<ShoppingListItemResponse> items
+) {
+}

--- a/src/main/java/com/nomnomnow/nnnbackend/dto/response/ShoppingListSummaryResponse.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/dto/response/ShoppingListSummaryResponse.java
@@ -1,0 +1,12 @@
+package com.nomnomnow.nnnbackend.dto.response;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+public record ShoppingListSummaryResponse(
+        Long id,
+        LocalDate weekStart,
+        OffsetDateTime createdAt,
+        int itemCount
+) {
+}

--- a/src/main/java/com/nomnomnow/nnnbackend/entity/ShoppingList.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/entity/ShoppingList.java
@@ -1,0 +1,44 @@
+package com.nomnomnow.nnnbackend.entity;
+
+import com.nomnomnow.nnnbackend.user.AppUser;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Data
+@Table(name = "shopping_list", schema = "app")
+@RequiredArgsConstructor
+@EqualsAndHashCode(exclude = {"owner", "items"})
+public class ShoppingList {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private AppUser owner;
+
+    @Column(name = "week_start", nullable = false)
+    private LocalDate weekStart;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @OneToMany(mappedBy = "shoppingList", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ShoppingListItem> items = new ArrayList<>();
+
+    public void addItem(ShoppingListItem item) {
+        item.setShoppingList(this);
+        items.add(item);
+    }
+}

--- a/src/main/java/com/nomnomnow/nnnbackend/entity/ShoppingListItem.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/entity/ShoppingListItem.java
@@ -1,0 +1,34 @@
+package com.nomnomnow.nnnbackend.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Data
+@Table(name = "shopping_list_item", schema = "app")
+@RequiredArgsConstructor
+@EqualsAndHashCode(exclude = "shoppingList")
+public class ShoppingListItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shopping_list_id", nullable = false)
+    private ShoppingList shoppingList;
+
+    @Column(name = "ingredient_name", nullable = false)
+    private String ingredientName;
+
+    @Column(name = "quantity", precision = 10, scale = 2, nullable = false)
+    private BigDecimal quantity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "unit", nullable = false)
+    private Unit unit;
+}

--- a/src/main/java/com/nomnomnow/nnnbackend/repository/RecipePlanRepository.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/repository/RecipePlanRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RecipePlanRepository extends JpaRepository<RecipePlan, Long> {
@@ -26,6 +27,8 @@ public interface RecipePlanRepository extends JpaRepository<RecipePlan, Long> {
             @Param("endDate") LocalDate endDate);
 
     boolean existsByOwnerAndPlanDateBetween(AppUser owner, LocalDate startDate, LocalDate endDate);
+
+    Optional<RecipePlan> findByOwnerAndPlanDate(AppUser owner, LocalDate planDate);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     void deleteByOwnerAndPlanDateBetween(AppUser owner, LocalDate startDate, LocalDate endDate);

--- a/src/main/java/com/nomnomnow/nnnbackend/repository/RecipeRepository.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/repository/RecipeRepository.java
@@ -51,4 +51,11 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     @Query("SELECT r FROM Recipe r ORDER BY function('random')")
     List<Recipe> findRandomRecipes(Pageable pageable);
+
+    @Query("""
+        SELECT r FROM Recipe r
+        WHERE r.id <> :excludedRecipeId
+        ORDER BY function('random')
+    """)
+    List<Recipe> findRandomRecipesExcluding(@Param("excludedRecipeId") Long excludedRecipeId, Pageable pageable);
 }

--- a/src/main/java/com/nomnomnow/nnnbackend/repository/ShoppingListRepository.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/repository/ShoppingListRepository.java
@@ -1,0 +1,21 @@
+package com.nomnomnow.nnnbackend.repository;
+
+import com.nomnomnow.nnnbackend.entity.ShoppingList;
+import com.nomnomnow.nnnbackend.user.AppUser;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ShoppingListRepository extends JpaRepository<ShoppingList, Long> {
+
+    @EntityGraph(attributePaths = "items")
+    @Query("SELECT DISTINCT sl FROM ShoppingList sl WHERE sl.owner = :owner ORDER BY sl.createdAt DESC")
+    List<ShoppingList> findByOwnerOrderByCreatedAtDesc(@Param("owner") AppUser owner);
+
+    @EntityGraph(attributePaths = "items")
+    Optional<ShoppingList> findByIdAndOwner(Long id, AppUser owner);
+}

--- a/src/main/java/com/nomnomnow/nnnbackend/service/RecipePlanService.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/service/RecipePlanService.java
@@ -37,10 +37,14 @@ public class RecipePlanService {
 
     @Transactional
     public List<RecipePlanResponse> getWeeklyPlan(LocalDate weekStart) {
+        return mapToResponses(getOrCreateWeeklyPlansForCurrentUser(weekStart));
+    }
+
+    @Transactional
+    public List<RecipePlan> getOrCreateWeeklyPlansForCurrentUser(LocalDate weekStart) {
         AppUser currentUser = currentUserService.getCurrentUser();
         LocalDate normalizedWeekStart = normalizeWeekStart(weekStart);
         validateWeekAccess(currentUser, normalizedWeekStart);
-
         LocalDate weekEnd = normalizedWeekStart.plusDays(DAYS_IN_WEEK - 1);
 
         List<RecipePlan> plans = recipePlanRepository.findByOwnerAndDateRange(
@@ -50,7 +54,7 @@ public class RecipePlanService {
             plans = generateWeeklyPlan(currentUser, normalizedWeekStart);
         }
 
-        return mapToResponses(plans);
+        return plans;
     }
 
     @Transactional
@@ -76,6 +80,20 @@ public class RecipePlanService {
         return mapToResponses(savedPlans);
     }
 
+    @Transactional
+    public RecipePlanResponse refreshPlanDay(LocalDate planDate) {
+        AppUser currentUser = currentUserService.getCurrentUser();
+        validateWeekRefreshAccess(normalizeWeekStart(planDate));
+
+        RecipePlan plan = recipePlanRepository.findByOwnerAndPlanDate(currentUser, planDate)
+                .orElseGet(() -> createPlan(currentUser, planDate));
+        Long currentRecipeId = plan.getRecipe() != null ? plan.getRecipe().getId() : null;
+
+        plan.setRecipe(findRandomRecipeForDay(currentRecipeId));
+
+        return mapToResponse(recipePlanRepository.save(plan));
+    }
+
     private List<RecipePlan> generateWeeklyPlan(AppUser currentUser, LocalDate weekStart) {
         LocalDate weekEnd = weekStart.plusDays(DAYS_IN_WEEK - 1);
 
@@ -97,19 +115,40 @@ public class RecipePlanService {
                 .orElseThrow(() -> new ResourceNotFoundException("Recipe not found with id: " + recipeId));
     }
 
+    private Recipe findRandomRecipeForDay(Long currentRecipeId) {
+        List<Recipe> randomRecipes = currentRecipeId == null
+                ? recipeRepository.findRandomRecipes(PageRequest.of(0, 1))
+                : recipeRepository.findRandomRecipesExcluding(currentRecipeId, PageRequest.of(0, 1));
+
+        if (randomRecipes.isEmpty() && currentRecipeId != null) {
+            randomRecipes = recipeRepository.findRandomRecipes(PageRequest.of(0, 1));
+        }
+
+        if (randomRecipes.isEmpty()) {
+            throw new BadRequestException("No recipes available for refreshing this meal plan day");
+        }
+
+        return randomRecipes.getFirst();
+    }
+
     private List<RecipePlan> createPlans(AppUser owner, List<Recipe> recipes, LocalDate weekStart) {
         List<RecipePlan> plans = new ArrayList<>();
 
         for (int i = 0; i < recipes.size(); i++) {
-            RecipePlan plan = new RecipePlan();
-            plan.setOwner(owner);
+            RecipePlan plan = createPlan(owner, weekStart.plusDays(i));
             plan.setRecipe(recipes.get(i));
-            plan.setPlanDate(weekStart.plusDays(i));
 
             plans.add(plan);
         }
 
         return plans;
+    }
+
+    private RecipePlan createPlan(AppUser owner, LocalDate planDate) {
+        RecipePlan plan = new RecipePlan();
+        plan.setOwner(owner);
+        plan.setPlanDate(planDate);
+        return plan;
     }
 
     private List<RecipePlanResponse> mapToResponses(List<RecipePlan> plans) {

--- a/src/main/java/com/nomnomnow/nnnbackend/service/ShoppingListService.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/service/ShoppingListService.java
@@ -1,0 +1,136 @@
+package com.nomnomnow.nnnbackend.service;
+
+import com.nomnomnow.nnnbackend.dto.request.ShoppingListRequest;
+import com.nomnomnow.nnnbackend.dto.response.ShoppingListItemResponse;
+import com.nomnomnow.nnnbackend.dto.response.ShoppingListResponse;
+import com.nomnomnow.nnnbackend.dto.response.ShoppingListSummaryResponse;
+import com.nomnomnow.nnnbackend.entity.RecipeComponent;
+import com.nomnomnow.nnnbackend.entity.ShoppingList;
+import com.nomnomnow.nnnbackend.entity.ShoppingListItem;
+import com.nomnomnow.nnnbackend.entity.Unit;
+import com.nomnomnow.nnnbackend.exception.BadRequestException;
+import com.nomnomnow.nnnbackend.exception.ResourceNotFoundException;
+import com.nomnomnow.nnnbackend.repository.ShoppingListRepository;
+import com.nomnomnow.nnnbackend.user.AppUser;
+import com.nomnomnow.nnnbackend.user.CurrentUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import static java.time.DayOfWeek.MONDAY;
+
+@Service
+@RequiredArgsConstructor
+public class ShoppingListService {
+
+    private final ShoppingListRepository shoppingListRepository;
+    private final RecipePlanService recipePlanService;
+    private final CurrentUserService currentUserService;
+
+    @Transactional
+    public ShoppingListResponse generateShoppingList(ShoppingListRequest request) {
+        AppUser currentUser = currentUserService.getCurrentUser();
+        var weekStart = request.weekStart().with(TemporalAdjusters.previousOrSame(MONDAY));
+        var plans = recipePlanService.getOrCreateWeeklyPlansForCurrentUser(weekStart);
+        var aggregatedItems = aggregateItems(plans.stream()
+                .flatMap(plan -> plan.getRecipe().getComponents().stream())
+                .toList());
+
+        if (aggregatedItems.isEmpty()) {
+            throw new BadRequestException("Cannot generate a shopping list without recipe ingredients");
+        }
+
+        var shoppingList = new ShoppingList();
+        shoppingList.setOwner(currentUser);
+        shoppingList.setWeekStart(weekStart);
+        aggregatedItems.forEach(shoppingList::addItem);
+
+        return mapToResponse(shoppingListRepository.saveAndFlush(shoppingList));
+    }
+
+    @Transactional(readOnly = true)
+    public List<ShoppingListSummaryResponse> getShoppingLists() {
+        AppUser currentUser = currentUserService.getCurrentUser();
+
+        return shoppingListRepository.findByOwnerOrderByCreatedAtDesc(currentUser).stream()
+                .map(this::mapToSummaryResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ShoppingListResponse getShoppingList(Long id) {
+        AppUser currentUser = currentUserService.getCurrentUser();
+
+        return shoppingListRepository.findByIdAndOwner(id, currentUser)
+                .map(this::mapToResponse)
+                .orElseThrow(() -> new ResourceNotFoundException("Shopping list not found with id: " + id));
+    }
+
+    private List<ShoppingListItem> aggregateItems(List<RecipeComponent> components) {
+        var itemsByIngredientAndUnit = new LinkedHashMap<ShoppingListItemKey, ShoppingListItem>();
+
+        for (RecipeComponent component : components) {
+            if (component.getIngredient() == null || component.getQuantity() == null || component.getUnit() == null) {
+                continue;
+            }
+
+            var key = new ShoppingListItemKey(component.getIngredient().getName(), component.getUnit());
+            var item = itemsByIngredientAndUnit.computeIfAbsent(key, ignored -> createItem(component));
+            item.setQuantity(item.getQuantity().add(component.getQuantity()));
+        }
+
+        return itemsByIngredientAndUnit.values().stream()
+                .sorted(Comparator
+                        .comparing(ShoppingListItem::getIngredientName, String.CASE_INSENSITIVE_ORDER)
+                        .thenComparing(item -> item.getUnit().name()))
+                .toList();
+    }
+
+    private ShoppingListItem createItem(RecipeComponent component) {
+        var item = new ShoppingListItem();
+        item.setIngredientName(component.getIngredient().getName());
+        item.setUnit(component.getUnit());
+        item.setQuantity(BigDecimal.ZERO);
+        return item;
+    }
+
+    private ShoppingListSummaryResponse mapToSummaryResponse(ShoppingList shoppingList) {
+        return new ShoppingListSummaryResponse(
+                shoppingList.getId(),
+                shoppingList.getWeekStart(),
+                shoppingList.getCreatedAt(),
+                shoppingList.getItems().size()
+        );
+    }
+
+    private ShoppingListResponse mapToResponse(ShoppingList shoppingList) {
+        return new ShoppingListResponse(
+                shoppingList.getId(),
+                shoppingList.getWeekStart(),
+                shoppingList.getCreatedAt(),
+                shoppingList.getItems().stream()
+                        .sorted(Comparator
+                                .comparing(ShoppingListItem::getIngredientName, String.CASE_INSENSITIVE_ORDER)
+                                .thenComparing(item -> item.getUnit().name()))
+                        .map(this::mapToItemResponse)
+                        .toList()
+        );
+    }
+
+    private ShoppingListItemResponse mapToItemResponse(ShoppingListItem item) {
+        return new ShoppingListItemResponse(
+                item.getIngredientName(),
+                item.getQuantity(),
+                item.getUnit()
+        );
+    }
+
+    private record ShoppingListItemKey(String ingredientName, Unit unit) {
+    }
+}

--- a/src/test/java/com/nomnomnow/nnnbackend/service/RecipePlanServiceTest.java
+++ b/src/test/java/com/nomnomnow/nnnbackend/service/RecipePlanServiceTest.java
@@ -1,0 +1,151 @@
+package com.nomnomnow.nnnbackend.service;
+
+import com.nomnomnow.nnnbackend.dto.response.RecipeResponse;
+import com.nomnomnow.nnnbackend.entity.Recipe;
+import com.nomnomnow.nnnbackend.entity.RecipePlan;
+import com.nomnomnow.nnnbackend.exception.BadRequestException;
+import com.nomnomnow.nnnbackend.mapper.RecipeMapper;
+import com.nomnomnow.nnnbackend.repository.RecipePlanRepository;
+import com.nomnomnow.nnnbackend.repository.RecipeRepository;
+import com.nomnomnow.nnnbackend.user.AppUser;
+import com.nomnomnow.nnnbackend.user.CurrentUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecipePlanServiceTest {
+
+    @Mock
+    private RecipePlanRepository recipePlanRepository;
+
+    @Mock
+    private RecipeRepository recipeRepository;
+
+    @Mock
+    private RecipeMapper recipeMapper;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    private RecipePlanService recipePlanService;
+
+    @BeforeEach
+    void setUp() {
+        recipePlanService = new RecipePlanService(
+                recipePlanRepository,
+                recipeRepository,
+                recipeMapper,
+                currentUserService
+        );
+    }
+
+    @Test
+    void refreshPlanDayReplacesOnlyTheSelectedDayRecipe() {
+        var owner = user(42L);
+        var planDate = currentWeekStart().plusDays(2);
+        var existingRecipe = recipe(1L, "Old soup");
+        var replacementRecipe = recipe(2L, "New pasta");
+        var existingPlan = plan(10L, owner, existingRecipe, planDate);
+        var responseRecipe = responseRecipe(replacementRecipe);
+
+        when(currentUserService.getCurrentUser()).thenReturn(owner);
+        when(recipePlanRepository.findByOwnerAndPlanDate(owner, planDate)).thenReturn(Optional.of(existingPlan));
+        when(recipeRepository.findRandomRecipesExcluding(1L, PageRequest.of(0, 1)))
+                .thenReturn(List.of(replacementRecipe));
+        when(recipePlanRepository.save(existingPlan)).thenReturn(existingPlan);
+        when(recipeMapper.toResponse(replacementRecipe)).thenReturn(responseRecipe);
+
+        var response = recipePlanService.refreshPlanDay(planDate);
+
+        assertThat(existingPlan.getRecipe()).isEqualTo(replacementRecipe);
+        assertThat(response.planDate()).isEqualTo(planDate);
+        assertThat(response.recipe()).isEqualTo(responseRecipe);
+        verify(recipePlanRepository, never()).deleteByOwnerAndPlanDateBetween(any(), any(), any());
+    }
+
+    @Test
+    void refreshPlanDayCreatesTheSelectedDayWhenItDoesNotExistYet() {
+        var owner = user(42L);
+        var planDate = currentWeekStart().plusDays(4);
+        var recipe = recipe(3L, "Curry");
+
+        when(currentUserService.getCurrentUser()).thenReturn(owner);
+        when(recipePlanRepository.findByOwnerAndPlanDate(owner, planDate)).thenReturn(Optional.empty());
+        when(recipeRepository.findRandomRecipes(PageRequest.of(0, 1))).thenReturn(List.of(recipe));
+        when(recipePlanRepository.save(any(RecipePlan.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(recipeMapper.toResponse(recipe)).thenReturn(responseRecipe(recipe));
+
+        var response = recipePlanService.refreshPlanDay(planDate);
+
+        assertThat(response.planDate()).isEqualTo(planDate);
+        assertThat(response.recipe().id()).isEqualTo(3L);
+    }
+
+    @Test
+    void refreshPlanDayRejectsPastWeeks() {
+        var owner = user(42L);
+
+        when(currentUserService.getCurrentUser()).thenReturn(owner);
+
+        assertThatThrownBy(() -> recipePlanService.refreshPlanDay(currentWeekStart().minusWeeks(1)))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Cannot refresh meal plans from past weeks");
+
+        verify(recipePlanRepository, never()).findByOwnerAndPlanDate(any(), any());
+    }
+
+    private AppUser user(Long id) {
+        var user = new AppUser();
+        user.setId(id);
+        return user;
+    }
+
+    private Recipe recipe(Long id, String name) {
+        var recipe = new Recipe();
+        recipe.setId(id);
+        recipe.setName(name);
+        return recipe;
+    }
+
+    private RecipePlan plan(Long id, AppUser owner, Recipe recipe, LocalDate planDate) {
+        var plan = new RecipePlan();
+        plan.setId(id);
+        plan.setOwner(owner);
+        plan.setRecipe(recipe);
+        plan.setPlanDate(planDate);
+        return plan;
+    }
+
+    private RecipeResponse responseRecipe(Recipe recipe) {
+        return new RecipeResponse(
+                recipe.getId(),
+                recipe.getName(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of()
+        );
+    }
+
+    private LocalDate currentWeekStart() {
+        return LocalDate.now().with(java.time.DayOfWeek.MONDAY);
+    }
+}

--- a/src/test/java/com/nomnomnow/nnnbackend/service/ShoppingListServiceTest.java
+++ b/src/test/java/com/nomnomnow/nnnbackend/service/ShoppingListServiceTest.java
@@ -1,0 +1,152 @@
+package com.nomnomnow.nnnbackend.service;
+
+import com.nomnomnow.nnnbackend.dto.request.ShoppingListRequest;
+import com.nomnomnow.nnnbackend.entity.*;
+import com.nomnomnow.nnnbackend.exception.ResourceNotFoundException;
+import com.nomnomnow.nnnbackend.repository.ShoppingListRepository;
+import com.nomnomnow.nnnbackend.user.AppUser;
+import com.nomnomnow.nnnbackend.user.CurrentUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ShoppingListServiceTest {
+
+    @Mock
+    private ShoppingListRepository shoppingListRepository;
+
+    @Mock
+    private RecipePlanService recipePlanService;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    private ShoppingListService shoppingListService;
+
+    @BeforeEach
+    void setUp() {
+        shoppingListService = new ShoppingListService(
+                shoppingListRepository,
+                recipePlanService,
+                currentUserService
+        );
+    }
+
+    @Test
+    void generateShoppingListAggregatesEqualIngredientsWithSameUnit() {
+        var owner = user(42L);
+        var weekStart = LocalDate.now().with(java.time.DayOfWeek.MONDAY);
+        var pasta = recipe(component("Tomato", "2.50", Unit.PIECE), component("Salt", "1.00", Unit.GRAM));
+        var soup = recipe(component("Tomato", "1.50", Unit.PIECE), component("Salt", "1.00", Unit.TEASPOON));
+
+        when(currentUserService.getCurrentUser()).thenReturn(owner);
+        when(recipePlanService.getOrCreateWeeklyPlansForCurrentUser(weekStart))
+                .thenReturn(List.of(plan(owner, pasta, weekStart), plan(owner, soup, weekStart.plusDays(1))));
+        when(shoppingListRepository.saveAndFlush(any(ShoppingList.class))).thenAnswer(invocation -> {
+            var shoppingList = (ShoppingList) invocation.getArgument(0);
+            shoppingList.setId(7L);
+            shoppingList.setCreatedAt(OffsetDateTime.parse("2026-05-31T12:00:00Z"));
+            return shoppingList;
+        });
+
+        var response = shoppingListService.generateShoppingList(new ShoppingListRequest(weekStart));
+
+        assertThat(response.id()).isEqualTo(7L);
+        assertThat(response.weekStart()).isEqualTo(weekStart);
+        assertThat(response.items()).extracting("ingredientName")
+                .containsExactly("Salt", "Salt", "Tomato");
+        assertThat(response.items()).extracting("quantity")
+                .containsExactly(
+                        new BigDecimal("1.00"),
+                        new BigDecimal("1.00"),
+                        new BigDecimal("4.00")
+                );
+        assertThat(response.items()).extracting("unit")
+                .containsExactly(Unit.GRAM, Unit.TEASPOON, Unit.PIECE);
+    }
+
+    @Test
+    void generateShoppingListCreatesANewSnapshotEveryTime() {
+        var owner = user(42L);
+        var weekStart = LocalDate.now().with(java.time.DayOfWeek.MONDAY);
+        var recipe = recipe(component("Rice", "2.00", Unit.GRAM));
+
+        when(currentUserService.getCurrentUser()).thenReturn(owner);
+        when(recipePlanService.getOrCreateWeeklyPlansForCurrentUser(weekStart))
+                .thenReturn(List.of(plan(owner, recipe, weekStart)));
+        when(shoppingListRepository.saveAndFlush(any(ShoppingList.class))).thenAnswer(invocation -> {
+            var shoppingList = (ShoppingList) invocation.getArgument(0);
+            shoppingList.setId(shoppingList.getId() == null ? 1L : shoppingList.getId() + 1L);
+            shoppingList.setCreatedAt(OffsetDateTime.parse("2026-05-31T12:00:00Z"));
+            return shoppingList;
+        });
+
+        shoppingListService.generateShoppingList(new ShoppingListRequest(weekStart));
+        shoppingListService.generateShoppingList(new ShoppingListRequest(weekStart));
+
+        verify(shoppingListRepository, org.mockito.Mockito.times(2)).saveAndFlush(any(ShoppingList.class));
+    }
+
+    @Test
+    void getShoppingListOnlyReturnsListsForCurrentUser() {
+        var owner = user(42L);
+
+        when(currentUserService.getCurrentUser()).thenReturn(owner);
+        when(shoppingListRepository.findByIdAndOwner(99L, owner)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> shoppingListService.getShoppingList(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Shopping list not found with id: 99");
+    }
+
+    private AppUser user(Long id) {
+        var user = new AppUser();
+        user.setId(id);
+        return user;
+    }
+
+    private Recipe recipe(RecipeComponent... components) {
+        var recipe = new Recipe();
+        recipe.setId(1L);
+        recipe.setName("Recipe");
+        for (RecipeComponent component : components) {
+            component.setRecipe(recipe);
+            recipe.getComponents().add(component);
+        }
+        return recipe;
+    }
+
+    private RecipeComponent component(String ingredientName, String quantity, Unit unit) {
+        var ingredient = new Ingredient();
+        ingredient.setName(ingredientName);
+
+        var component = new RecipeComponent();
+        component.setIngredient(ingredient);
+        component.setQuantity(new BigDecimal(quantity));
+        component.setUnit(unit);
+        return component;
+    }
+
+    private RecipePlan plan(AppUser owner, Recipe recipe, LocalDate planDate) {
+        var plan = new RecipePlan();
+        plan.setOwner(owner);
+        plan.setRecipe(recipe);
+        plan.setPlanDate(planDate);
+        return plan;
+    }
+}


### PR DESCRIPTION
## Summary
- add per-day refresh support for weekly plans
- add persisted shopping-list snapshots generated from a weekly plan
- add shopping-list REST endpoints, DTOs, entities, repositories, and Flyway migration
- aggregate shopping-list items by ingredient name and unit

## Validation
- mvn test
- initial sandboxed run failed only because Testcontainers could not access Docker; rerun with Docker access passed