### PR TITLE
Return 401 for unauthenticated API requests

### DIFF
--- a/src/main/java/com/nomnomnow/nnnbackend/config/SecurityConfig.java
+++ b/src/main/java/com/nomnomnow/nnnbackend/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.nomnomnow.nnnbackend.config;
 
 import com.nomnomnow.nnnbackend.user.AppUserService;
 import com.nomnomnow.nnnbackend.user.DevAuthenticationFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
@@ -18,6 +20,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 
 import java.util.Arrays;
 
@@ -62,12 +65,42 @@ public class SecurityConfig {
                                 .userService(oAuth2UserService(appUserService))
                         )
                         .defaultSuccessUrl(frontendUrl + "/home", true)
+                )
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            if (isApiRequest(request)) {
+                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Not authenticated");
+                                return;
+                            }
+
+                            new LoginUrlAuthenticationEntryPoint("/oauth2/authorization/google")
+                                    .commence(request, response, authException);
+                        })
                 );
         return http.build();
     }
 
     private boolean isDevProfile(Environment environment) {
         return Arrays.asList(environment.getActiveProfiles()).contains("dev");
+    }
+
+    private boolean isApiRequest(HttpServletRequest request) {
+        var uri = request.getRequestURI();
+        if (uri.startsWith("/api/") || uri.startsWith("/auth/")) {
+            return true;
+        }
+
+        if (uri.startsWith("/recipes") && !HttpMethod.GET.matches(request.getMethod())) {
+            return true;
+        }
+
+        var requestedWith = request.getHeader("X-Requested-With");
+        if ("XMLHttpRequest".equals(requestedWith)) {
+            return true;
+        }
+
+        var accept = request.getHeader("Accept");
+        return accept != null && accept.contains("application/json");
     }
 
     private OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService(AppUserService appUserService) {
@@ -79,4 +112,3 @@ public class SecurityConfig {
         };
     }
 }
-


### PR DESCRIPTION
## Summary

Updates Spring Security handling for unauthenticated requests.

- API/auth/XHR-style requests now receive 401 Unauthorized
- normal browser navigation still enters the OAuth login flow

## Why

When the session cookie expired, frontend fetch calls could receive login-flow behavior instead of a clear unauthenticated API response. Returning 401 lets the frontend detect the expired session and redirect the user to the login page with a useful message.

## Validation

- ./mvnw test (31 tests passed on the PR branch)

Note: the first Maven run inside the sandbox failed on the local .m2 lockfile; the validation command passed after running with local Maven repository access.